### PR TITLE
Added option for setting global logging level

### DIFF
--- a/fluentd/init.sls
+++ b/fluentd/init.sls
@@ -29,7 +29,10 @@ fluentd_control_script:
 configure_fluentd_service:
   file.managed:
     - name: {{ service.destination_path }}
-    - source: salt://fluentd/files/{{ service.source_path }}
+    - source: salt://fluentd/templates/{{ service.source_path }}
+    - template: jinja
+    - context:
+        log_level: {{ fluentd.global_log_level }}
 
 start_fluentd_service:
   service.running:

--- a/fluentd/map.jinja
+++ b/fluentd/map.jinja
@@ -2,6 +2,7 @@
     'default': {
         'service': 'fluentd',
         'conf_file': '/etc/fluent/fluent.conf',
+        'global_log_level': 'info'
     },
     'Debian': {
         'pkgs': [

--- a/fluentd/templates/fluent.conf
+++ b/fluentd/templates/fluent.conf
@@ -1,5 +1,5 @@
 <system>
-  log_level warn
+  log_level {{ log_level }}
 </system>
 
 @include fluent.d/*.conf


### PR DESCRIPTION
Moved the base config file to templates and added an option to override
the global log level for Fluentd
