### PR TITLE
Added Nginx proxy for HTTP log endpoints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,12 +19,22 @@ Available states
 ``fluentd``
 -----------
 
-TODO - add description of this state
+Install the FluentD service for shipping and aggregating logs and other data.
 
 ``fluentd.conf``
 ----------------
 
-TODO - add description of this state
+Configure the installed FluentD service based on pillar data
+
+``fluentd.plugins``
+-------------------
+
+Install plugins for extending FluentD based on pillar data
+
+``fluentd.reverse_proxy``
+-------------------------
+
+Install and configure an Nginx HTTPS reverse proxy for encrypting traffic to HTTP based endpoints
 
 
 Template

--- a/fluentd/init.sls
+++ b/fluentd/init.sls
@@ -1,5 +1,4 @@
 {% from "fluentd/map.jinja" import fluentd, fluentd_service with context %}
-{% set service = fluentd_service.get(salt.test.provider('service'), fluentd_service.systemd) %}
 
 install_fluentd_dependencies:
   pkg.installed:
@@ -31,8 +30,8 @@ fluentd_control_script:
 
 configure_fluentd_service:
   file.managed:
-    - name: {{ service.destination_path }}
-    - source: salt://fluentd/files/{{ service.source_path }}
+    - name: {{ fluentd_service.destination_path }}
+    - source: salt://fluentd/files/{{ fluentd_service.source_path }}
 
 start_fluentd_service:
   service.running:

--- a/fluentd/map.jinja
+++ b/fluentd/map.jinja
@@ -2,7 +2,13 @@
     'default': {
         'service': 'fluentd',
         'conf_file': '/etc/fluent/fluent.conf',
-        'global_log_level': 'info'
+        'global_log_level': 'info',
+        'nginx_config': {
+            'cert_file': 'fluentd.example.com.crt',
+            'key_file': 'fluentd.example.com.key'
+        },
+        'ssl_directory': '/etc/ssl',
+        'nginx_site_path': '/etc/nginx/sites-enabled'
     },
     'Debian': {
         'pkgs': [
@@ -19,9 +25,9 @@
             'make'
         ]
     },
-}, grain='os_family', merge=salt.pillar.get('fluentd:lookup'), base='default') %}
+}, grain='os_family', merge=salt.pillar.get('fluentd:overrides'), base='default') %}
 
-{% set fluentd_service = {
+{% set fluentd_service = salt.grains.filter_by({
     'systemd': {
         'destination_path': '/etc/systemd/system/fluentd.service',
         'source_path': 'fluentd.service',
@@ -30,4 +36,4 @@
         'destination_path': '/etc/init/fluentd.conf',
         'source_path': 'fluentd.upstart',
     }
-} %}
+}, grain='init', merge=salt.pillar.get('fluentd:init_service')) %}

--- a/fluentd/reverse_proxy.sls
+++ b/fluentd/reverse_proxy.sls
@@ -1,0 +1,75 @@
+{% from "fluentd/map.jinja" import fluentd with context %}
+
+fluentd_install_nginx:
+  pkg.installed:
+    - name: nginx
+    - refresh: True
+
+ensure_fluentd_ssl_directory:
+  file.directory:
+    - name: {{ fluentd.ssl_directory }}/certs
+    - makedirs: True
+
+{% if fluentd.nginx_config.get('cert_source') %}
+setup_fluentd_ssl_cert:
+  file.managed:
+    - name: {{fluentd.ssl_directory}}/certs/{{ fluentd.nginx_config.cert_file }}
+    {% if fluentd.nginx_config.cert_source %}
+    - source: {{ fluentd.nginx_config.cert_source }}
+    {% elif fluentd.nginx_config.cert_contents %}
+    - contents: |
+        {{ fluentd.nginx_config.cert_contents | indent(8) }}
+    {% endif %}
+    - makedirs: True
+
+setup_fluentd_ssl_key:
+  file.managed:
+    - name: {{fluentd.ssl_directory}}/certs/{{ fluentd.nginx_config.key_file }}
+    {% if fluentd.nginx_config.key_source %}
+    - source: {{ fluentd.nginx_config.key_source }}
+    {% elif fluentd.nginx_config.key_contents %}
+    - contents: |
+        {{ fluentd.nginx_config.key_contents | indent(8) }}
+    {% endif %}
+    - makedirs: True
+{% else %}
+setup_fluentd_ssl_cert:
+  module.run:
+    - name: tls.create_self_signed_cert
+    - tls_dir: ''
+    - cacert_path: {{ fluentd.ssl_directory }}
+    - makedirs: True
+    {% for arg, val in salt.pillar.get('fluentd:ssl:cert_params', {}).items() -%}
+    - {{ arg }}: {{ val }}
+    {% endfor -%}
+{% endif %}
+
+generate_nginx_dhparam:
+  cmd.run:
+    - name: openssl dhparam -out dhparam.pem 2048
+    - cwd: {{ fluentd.ssl_directory }}/certs
+    - unless: "[ -e {{ fluentd.ssl_directory }}/dhparam.pem ]"
+    - require:
+        - file: ensure_fluentd_ssl_directory
+
+configure_fluentd_nginx:
+  file.managed:
+    - name: {{ fluentd.nginx_site_path }}/fluentd
+    - source: salt://fluentd/templates/nginx_proxy.conf
+    - template: jinja
+    - makedirs: True
+    - context:
+        config: {{ fluentd.nginx_config }}
+        ssl_directory: {{ fluentd.ssl_directory }}/certs
+        plugins: {{ salt.pillar.get('proxied_plugins', []) }}
+
+remove_default_nginx_config:
+  file.absent:
+    - name: {{ fluentd.nginx_site_path }}/default
+
+nginx_service_running:
+  service.running:
+    - name: nginx
+    - enable: True
+    - watch:
+        - file: configure_fluentd_nginx

--- a/fluentd/templates/nginx_proxy.conf
+++ b/fluentd/templates/nginx_proxy.conf
@@ -1,0 +1,74 @@
+server {
+    listen 80;
+    listen [::]:80;
+    {% if config.get('server_name') -%}
+    server_name {{ config.server_name }};
+    {%- endif %}
+
+    # Redirect all HTTP requests to HTTPS with a 301 Moved Permanently response.
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    {% if config.get('server_name') -%}
+    server_name {{ config.server_name }};
+    {%- endif %}
+
+    # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
+    ssl_certificate {{ ssl_directory }}/{{ config.cert_file }};
+    ssl_certificate_key {{ ssl_directory }}/{{ config.key_file }};
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+    ssl_dhparam {{ ssl_directory }}/dhparam.pem;
+
+    # modern configuration. tweak to your needs.
+    ssl_protocols TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+    ssl_prefer_server_ciphers on;
+
+    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+    add_header Strict-Transport-Security max-age=15768000;
+
+    # OCSP Stapling ---
+    # fetch OCSP records from URL in ssl_certificate and cache them
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    resolver 8.8.8.8;
+
+    {% if config.get('root_path') %}
+    root {{ config.root_path }};
+    {% endif %}
+    index index.html;
+
+    # start_extra_configs
+    # end_extra_configs
+
+    {% for plugin in plugins %}
+    location /{{ plugin.route }} {
+        {% if plugin.get('token') %}
+        if ($arg_token != {{ plugin.token }}) {
+            return 401;
+        }
+        {% endif %}
+        proxy_pass http://localhost:{{ plugin.get('port', 8000) }}/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+    }
+    {% endfor %}
+
+}
+
+server {
+    listen 127.0.0.1:80;
+    location /nginx_status {
+        stub_status on;
+        access_log off;
+    }
+}

--- a/fluentd/tests/init.sls
+++ b/fluentd/tests/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .test_reverse_proxy

--- a/fluentd/tests/test_reverse_proxy.sls
+++ b/fluentd/tests/test_reverse_proxy.sls
@@ -1,0 +1,46 @@
+{% from "fluentd/map.jinja" import fluentd with context %}
+
+test_nginx_is_installed:
+  testinfra.package:
+    - name: nginx
+    - is_installed: True
+
+test_ssl_directory:
+  testinfra.file:
+    - name: {{ fluentd.ssl_directory }}/certs
+    - exists: True
+    - is_directory: True
+
+test_ssl_certificate_present:
+  testinfra.file:
+    - name: {{ fluentd.ssl_directory }}/certs/{{ fluentd.nginx_config.cert_file }}
+    - exists: True
+    - is_file: True
+
+test_ssl_key_present:
+  testinfra.file:
+    - name: {{ fluentd.ssl_directory }}/certs/{{ fluentd.nginx_config.key_file }}
+    - exists: True
+    - is_file: True
+
+test_nginx_running:
+  testinfra.service:
+    - name: nginx
+    - is_running: True
+    - is_enabled: True
+
+test_nginx_site_configured:
+  testinfra.file:
+    - name: {{ fluentd.nginx_site_path }}/fluentd
+    - exists: True
+    - is_file: True
+
+test_nginx_listening_http:
+  testinfra.socket:
+    - name: tcp://0.0.0.0:80
+    - is_listening: True
+
+test_nginx_listening_https:
+  testinfra.socket:
+    - name: tcp://0.0.0.0:443
+    - is_listening: True

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,9 @@
 fluentd:
-  lookup:
+  overrides:
+  ssl:
+    cert_params:
+      CN: fluentd.example.com
+      bits: 4096
   plugins:
     - fluent-plugin-elasticsearch
     - fluent-plugin-postgres

--- a/scripts/vagrant_setup.sh
+++ b/scripts/vagrant_setup.sh
@@ -21,4 +21,5 @@ base:
   '*':
     - fluentd
     - fluentd.plugins
-    - fluentd.config" | sudo tee /srv/salt/top.sls
+    - fluentd.config
+    - fluentd.reverse_proxy" | sudo tee /srv/salt/top.sls


### PR DESCRIPTION
In order to allow for secure transport of logs from Heroku it is
necessary to place an HTTPS proxy on the aggregator servers. This pull
request adds a `reverse_proxy` state file to install and configure Nginx
for this purpose. Also supported is specifying a token to be passed in
the query param in order to reject requests not containing the token.

closes mitodl/salt-ops#34
