### PR TITLE
Go back to running as root by default

### DIFF
--- a/fluentd/install.sls
+++ b/fluentd/install.sls
@@ -1,18 +1,5 @@
 {% from "fluentd/map.jinja" import fluentd, fluentd_service with context %}
 
-create_fluentd_user:
-  user.present:
-    - name: {{ fluentd.user }}
-    - createhome: True
-    - shell: /bin/bash
-
-create_fluentd_group:
-  group.present:
-    - name: {{ fluentd.group }}
-    - addusers:
-        - {{ fluentd.user }}
-    - system: True
-
 install_fluentd_dependencies:
   pkg.installed:
     - pkgs: {{ fluentd.pkgs }}

--- a/fluentd/map.jinja
+++ b/fluentd/map.jinja
@@ -2,8 +2,8 @@
     'default': {
         'version': None,
         'service': 'fluentd',
-        'user': 'fluentd',
-        'group': 'fluentd',
+        'user': 'root',
+        'group': 'root',
         'conf_file': '/etc/fluent/fluent.conf',
         'global_log_level': 'info',
         'nginx_config': {

--- a/scripts/testinfra.sh
+++ b/scripts/testinfra.sh
@@ -15,4 +15,4 @@ else
     SRCDIR=/home/vagrant/sync
 fi
 sudo rm -rf $SRCDIR/tests/__pycache__
-sudo -u fluentd -i py.test $SRCDIR/tests -s
+sudo py.test $SRCDIR/tests -s


### PR DESCRIPTION
Revert recent changes to run as user 'fluentd' by default, which presents permissions problems for many typical installations.

FluentD can still be configured to run as another user, but it will be the responsibility of the site administrator to write states that ensure the user's existence and directory permissions.

See https://github.com/mitodl/salt-ops/issues/1049

I considered creating a new directory to hold `.pos` files, but realized that some of the most typical files that need to be monitored are owned by `root` and not world-readable; and there are bound to be others. (Examples include the syslog files owned by `root:adm` in `/var/log`, and Apache and Nginx access logs, which are not world-readable by default in most Linux distributions.) Having `root` be the default user creates the least amount of extra work for the user of this formula.
