### PR TITLE
Create directory for position files

### DIFF
--- a/fluentd/install.sls
+++ b/fluentd/install.sls
@@ -55,6 +55,15 @@ make_fluentd_pidfile_directory:
       - user
       - group
 
+make_fluentd_pos_file_directory:
+  file.directory:
+    - name: /var/lib/fluentd
+    - user: {{ fluentd.user }}
+    - group: {{ fluentd.group }}
+    - recurse:
+      - user
+      - group
+
 fluentd_control_script:
   file.managed:
     - name: /usr/local/bin/fluentd.sh


### PR DESCRIPTION
Create a directory for FluentD position (.pos) files, which is useful for avoiding clutter, or when running FluentD as a non-root user which does not have permissions to write to the directories containing the files it's watching.

Fixes https://github.com/mitodl/salt-ops/issues/1049

This is an alternative to https://github.com/mitodl/fluentd-formula/pull/12 as a solution for the issue above.
