### PR TITLE
Added ca_chain file creation and update

### DIFF
--- a/fluentd/config.sls
+++ b/fluentd/config.sls
@@ -35,6 +35,18 @@ create_{{ cert }}_file:
     - mode: '0400'
 {% endfor %}
 
+{% for ca_chain, details in salt.pillar.get('fluentd:pki', {}).items() %}
+create_{{ ca_chain }}_file:
+  file.managed:
+    - name: {{ details.path }}
+    - contents: |
+        {{ details.content|indent(8) }}
+
+update_ca_cert_store:
+  cmd.run:
+    - name: update-ca-certificates
+{% endfor %}
+
 reload_fluentd_service:
   service.running:
     - name: fluentd

--- a/pillar.example
+++ b/pillar.example
@@ -17,6 +17,13 @@ fluentd:
         (Your Private Key: www.example.com.key)
         -----END RSA PRIVATE KEY-----
       path: '/etc/fluentd/flunetd.key'
+  pki:
+    ca_chain:
+      content: |
+         -----BEGIN CERTIFICATE-----
+        (Your PKI cert chain)
+        -----END CERTIFICATE-----
+      path: '/usr/local/share/ca-certificates/ca_chain.crt'
   plugins:
     - fluent-plugin-elasticsearch
     - fluent-plugin-postgres


### PR DESCRIPTION
In order not to simplify our work with PKI and not have to include the entire chain in the fluentd client config, we opted to add the chain to the local ca store. This change, in conjunction with one to pillar.fluentd.init will write the ca_chain.crt file to the trusted store path and update that config.